### PR TITLE
Reorganize sender and receiver logic and clean up file structure

### DIFF
--- a/cmd/sender.go
+++ b/cmd/sender.go
@@ -12,7 +12,7 @@ import (
 
 func startSender(files []string) error {
 	s := sender.New()
-	defer s.CtxCancel()
+	defer s.Session.CtxCancel()
 
 	offerCh := make(chan string)
 	go func() {
@@ -32,7 +32,7 @@ func startSender(files []string) error {
 	var offer string
 	err = spinner.New().
 		Type(spinner.Dots).
-		Title("Generating offer").
+		Title("Creating offer").
 		Action(func() {
 			offer = <-offerCh
 		}).
@@ -66,7 +66,7 @@ func startSender(files []string) error {
 		return fmt.Errorf("transfer rejected")
 	}
 
-	return s.Send(ftList)
+	return s.SendFiles(ftList)
 }
 
 // exchangeSDP handles the SDP offer and answer exchange process

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -6,14 +6,6 @@ import (
 	"log/slog"
 )
 
-func (c *Session) AddRemote(remoteSDP *webrtc.SessionDescription) error {
-	err := c.Conn.SetRemoteDescription(*remoteSDP)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (c *Session) SetupPeerConn() error {
 	conn, err := webrtc.NewPeerConnection(webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{iceServers[0]},

--- a/proto/schema/control.proto
+++ b/proto/schema/control.proto
@@ -9,8 +9,6 @@ message FileMetadata {
   string file_name = 2;
   int64 file_size = 3;
   bool is_directory = 4;
-//  string file_type = 4; // MIME type: image/png, application/pdf
-//  int32 file_count = 4;
 }
 
 message FileMetadataList {

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -2,77 +2,14 @@ package receiver
 
 import (
 	"github.com/6b70/peerbeam/conn"
-	"github.com/6b70/peerbeam/proto/compiled/controlpb"
-	"github.com/6b70/peerbeam/utils"
 )
 
 type Receiver struct {
-	*conn.Session
+	Session *conn.Session
 }
 
 func New() *Receiver {
 	return &Receiver{
 		Session: conn.New(),
 	}
-}
-
-func (r *Receiver) SetupReceiverConn() error {
-	err := r.SetupPeerConn()
-	if err != nil {
-		return err
-	}
-	r.addChHandler()
-	return nil
-}
-
-func (r *Receiver) CreateAnswer(offer string) (string, error) {
-	offerSDP, err := utils.DecodeSDP(offer)
-	if err != nil {
-		return "", err
-	}
-	err = r.AddRemote(offerSDP)
-	if err != nil {
-		return "", err
-	}
-
-	answer, err := r.createSDP()
-	if err != nil {
-		return "", err
-	}
-
-	return answer, nil
-}
-
-func (r *Receiver) Receive(fileMDList *controlpb.FileMetadataList, destPath string) error {
-	err := r.receiveFiles(fileMDList, destPath)
-	if err != nil {
-		return err
-	}
-	// Doesn't always flush but this is handled in the sender
-	_ = r.DataCh.Close()
-	return nil
-}
-
-func (r *Receiver) createSDP() (string, error) {
-	initAnswer, err := r.Conn.CreateAnswer(nil)
-	if err != nil {
-		return "", err
-	}
-	err = r.Conn.SetLocalDescription(initAnswer)
-	if err != nil {
-		return "", err
-	}
-
-	r.CandidateCond.L.Lock()
-	r.CandidateCond.Wait()
-	r.CandidateCond.L.Unlock()
-
-	answer := r.Conn.LocalDescription()
-
-	encodedSDP, err := utils.EncodeSDP(answer)
-	if err != nil {
-		return "", err
-	}
-
-	return encodedSDP, nil
 }

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -1,93 +1,15 @@
 package sender
 
 import (
-	"fmt"
 	"github.com/6b70/peerbeam/conn"
-	"github.com/6b70/peerbeam/utils"
 )
 
 type Sender struct {
-	*conn.Session
+	Session *conn.Session
 }
 
 func New() *Sender {
 	return &Sender{
 		Session: conn.New(),
 	}
-}
-
-func (s *Sender) SetupSenderConn() (string, error) {
-	err := s.SetupPeerConn()
-	if err != nil {
-		return "", err
-	}
-	err = s.setupChs()
-	if err != nil {
-		return "", err
-	}
-
-	offer, err := s.createOffer()
-	if err != nil {
-		return "", err
-	}
-
-	return offer, nil
-}
-
-func (s *Sender) ProposeTransfer(ftList []utils.FileTransfer, answerStr string) error {
-	remoteSDP, err := utils.DecodeSDP(answerStr)
-	if err != nil {
-		return err
-	}
-
-	err = s.AddRemote(remoteSDP)
-	if err != nil {
-		return err
-	}
-
-	select {
-	case <-s.DataChOpen:
-		break
-	case <-s.Ctx.Done():
-		return fmt.Errorf("context cancelled")
-	}
-
-	err = s.sendTransferInfo(ftList)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *Sender) Send(ftList []utils.FileTransfer) error {
-	err := s.sendFiles(ftList)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *Sender) createOffer() (string, error) {
-	initialSDPOffer, err := s.Conn.CreateOffer(nil)
-	if err != nil {
-		return "", err
-	}
-	//done := webrtc.GatheringCompletePromise(s.Conn)
-	err = s.Conn.SetLocalDescription(initialSDPOffer)
-	if err != nil {
-		return "", err
-	}
-	//<-done
-
-	s.CandidateCond.L.Lock()
-	s.CandidateCond.Wait()
-	s.CandidateCond.L.Unlock()
-
-	sdpOffer := s.Conn.LocalDescription()
-	encodedSDP, err := utils.EncodeSDP(sdpOffer)
-	if err != nil {
-		return "", err
-	}
-
-	return encodedSDP, nil
 }

--- a/sender/setupConn.go
+++ b/sender/setupConn.go
@@ -1,17 +1,60 @@
 package sender
 
-func (s *Sender) setupChs() error {
-	ch, err := s.Conn.CreateDataChannel("data", nil)
-	if err != nil {
-		return err
-	}
-	s.DataChHandler(ch)
+import "github.com/6b70/peerbeam/utils"
 
-	ch, err = s.Conn.CreateDataChannel("candidate", nil)
+func (s *Sender) SetupSenderConn() (string, error) {
+	err := s.Session.SetupPeerConn()
+	if err != nil {
+		return "", err
+	}
+	err = s.createChs()
+	if err != nil {
+		return "", err
+	}
+
+	offer, err := s.createOffer()
+	if err != nil {
+		return "", err
+	}
+
+	return offer, nil
+}
+
+func (s *Sender) createOffer() (string, error) {
+	initialSDPOffer, err := s.Session.Conn.CreateOffer(nil)
+	if err != nil {
+		return "", err
+	}
+	err = s.Session.Conn.SetLocalDescription(initialSDPOffer)
+	if err != nil {
+		return "", err
+	}
+
+	s.Session.CandidateCond.L.Lock()
+	s.Session.CandidateCond.Wait()
+	s.Session.CandidateCond.L.Unlock()
+
+	sdpOffer := s.Session.Conn.LocalDescription()
+	encodedSDP, err := utils.EncodeSDP(sdpOffer)
+	if err != nil {
+		return "", err
+	}
+
+	return encodedSDP, nil
+}
+
+func (s *Sender) createChs() error {
+	ch, err := s.Session.Conn.CreateDataChannel("data", nil)
 	if err != nil {
 		return err
 	}
-	s.CandidateChHandler(ch)
+	s.Session.DataChHandler(ch)
+
+	ch, err = s.Session.Conn.CreateDataChannel("candidate", nil)
+	if err != nil {
+		return err
+	}
+	s.Session.CandidateChHandler(ch)
 
 	return nil
 }

--- a/utils/fileInfo.go
+++ b/utils/fileInfo.go
@@ -32,3 +32,19 @@ func ParseFiles(files []string) ([]FileTransfer, error) {
 	}
 	return ftList, nil
 }
+
+func ValidateDestPath(destPath string) (string, error) {
+	var err error
+	destPath, err = filepath.Abs(destPath)
+	if err != nil {
+		return "", err
+	}
+	destInfo, err := os.Stat(destPath)
+	if err != nil {
+		return "", err
+	}
+	if !destInfo.IsDir() {
+		return "", fmt.Errorf("destination path must be a directory")
+	}
+	return destPath, nil
+}


### PR DESCRIPTION
Refactored receiver and sender logic to simplify the session management flow. Also cleaned up the file structure by removing some redundant code and improving function organization.
Not huge changes but makes things a lot more readable.