### PR TITLE
Fix the bug where hole punching always fails when two computers cannot connect directly.

### DIFF
--- a/cmd/receiver.go
+++ b/cmd/receiver.go
@@ -86,7 +86,9 @@ func recvExchangeSDP() (string, error) {
 				CharLimit(5000).
 				Placeholder("Paste offer here...").
 				Value(&offer).
-				Validate(utils.ValidateSDP),
+				Validate(func(s string) error {
+					return nil
+				}),
 		),
 	)
 	err := form.Run()

--- a/cmd/sender.go
+++ b/cmd/sender.go
@@ -19,7 +19,7 @@ func startSender(files []string) error {
 		offer, err := s.SetupSenderConn()
 		if err != nil {
 			log.Errorln(err)
-			offerCh <- ""
+			close(offerCh)
 		}
 		offerCh <- offer
 	}()
@@ -82,10 +82,8 @@ func senderExchangeSDP(offer string) (string, error) {
 				Placeholder("Paste response here...").
 				Value(&answer).
 				Validate(func(s string) error {
-					if s == offer {
-						return fmt.Errorf("offer and answer cannot be the same")
-					}
-					return utils.ValidateSDP(s)
+					// here is no need to check
+					return nil
 				}),
 		),
 	)

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -14,10 +14,10 @@ func (c *Session) SetupPeerConn() error {
 		return err
 	}
 	c.Conn = conn
-	c.monitorState()
+	c.monitorConnectState()
+	c.monitorGatherState()
 	go c.connClose()
-	c.sendCandidatesHandler()
-
+	c.CandidatesHandler()
 	return nil
 }
 

--- a/conn/session.go
+++ b/conn/session.go
@@ -3,16 +3,12 @@ package conn
 import (
 	"context"
 	"github.com/pion/webrtc/v4"
+	log "github.com/sirupsen/logrus"
 	"sync"
-	"sync/atomic"
 )
 
 type Session struct {
 	Conn *webrtc.PeerConnection
-
-	candidateCh     *webrtc.DataChannel
-	candidateChOpen atomic.Bool
-	CandidateCond   *sync.Cond
 
 	DataCh *webrtc.DataChannel
 
@@ -21,16 +17,34 @@ type Session struct {
 	Ctx       context.Context
 	CtxCancel context.CancelFunc
 
-	MsgCh chan *webrtc.DataChannelMessage
+	MsgCh          chan *webrtc.DataChannelMessage
+	Candidates     []webrtc.ICECandidateInit
+	CandidatesLock sync.Mutex
+	GatherDone     chan struct{}
 }
 
 func New() *Session {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Session{
-		Ctx:           ctx,
-		CtxCancel:     cancel,
-		DataChOpen:    make(chan struct{}, 10),
-		CandidateCond: sync.NewCond(&sync.Mutex{}),
-		MsgCh:         make(chan *webrtc.DataChannelMessage, 200),
+		Ctx:        ctx,
+		CtxCancel:  cancel,
+		DataChOpen: make(chan struct{}, 10),
+		GatherDone: make(chan struct{}, 1),
+		MsgCh:      make(chan *webrtc.DataChannelMessage, 200),
+	}
+}
+
+func (c *Session) WaitGatherComplete() {
+	<-c.GatherDone
+}
+func (c *Session) AddCandidates(candidates []webrtc.ICECandidateInit) {
+	for i := range candidates {
+		err := c.Conn.AddICECandidate(candidates[i])
+		if err != nil {
+			log.Errorf("add ICECandidate error: %v candidate:%v", err, candidates[i])
+			continue
+		} else {
+			log.Debugf("add ICECandidate success candidate:%v", candidates[i])
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,27 +1,34 @@
 package main
 
 import (
+	"fmt"
 	"github.com/6b70/peerbeam/cmd"
 	log "github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+	"runtime"
 )
 
-//func configureLogger() {
-//	log.SetLevel(log.TraceLevel)
-//	log.SetReportCaller(true)
-//	callerFormatter := func(f *runtime.Frame) string {
-//		s := strings.Split(f.Function, ".")
-//		funcName := s[len(s)-1]
-//		return fmt.Sprintf(" [%s:%d][%s()]", path.Base(f.File), f.Line, funcName)
-//	}
-//	log.SetFormatter(&nested.Formatter{
-//		TimestampFormat:       "2006-01-02 15:04:05",
-//		CallerFirst:           true,
-//		CustomCallerFormatter: callerFormatter,
-//	})
-//}
+func configureLogger() {
+	log.SetReportCaller(true) // 关键配置：启用调用者信息
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: "2006-01-02 15:04:05", // 时间格式
+		FullTimestamp:   true,
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			filename := filepath.Base(f.File)
+			return "", fmt.Sprintf("%s:%d", filename, f.Line)
+		},
+	})
+	log.SetLevel(log.TraceLevel)
+	file, err := os.OpenFile("log/app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatal("无法创建日志文件: ", err)
+	}
+	log.SetOutput(file)
+}
 
 func main() {
-	//configureLogger()
+	configureLogger()
 	err := cmd.App()
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/6b70/peerbeam/cmd"
 	log "github.com/sirupsen/logrus"
-	"os"
+	"io"
 	"path/filepath"
 	"runtime"
 )
@@ -20,16 +20,16 @@ func configureLogger() {
 		},
 	})
 	log.SetLevel(log.TraceLevel)
-	err := os.MkdirAll("log", os.ModePerm)
-	if err != nil {
-		log.Fatal("failed to create log directory: ", err)
-	}
-
-	file, err := os.OpenFile("log/app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		log.Fatal("无法创建日志文件: ", err)
-	}
-	log.SetOutput(file)
+	//err := os.MkdirAll("log", os.ModePerm)
+	//if err != nil {
+	//	log.Fatal("failed to create log directory: ", err)
+	//}
+	//file, err := os.OpenFile("log/app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	//if err != nil {
+	//	log.Fatal("无法创建日志文件: ", err)
+	//}
+	//log.SetOutput(file)
+	log.SetOutput(io.Discard)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,11 @@ func configureLogger() {
 		},
 	})
 	log.SetLevel(log.TraceLevel)
+	err := os.MkdirAll("log", os.ModePerm)
+	if err != nil {
+		log.Fatal("failed to create log directory: ", err)
+	}
+
 	file, err := os.OpenFile("log/app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		log.Fatal("无法创建日志文件: ", err)

--- a/sender/setupConn.go
+++ b/sender/setupConn.go
@@ -29,13 +29,9 @@ func (s *Sender) createOffer() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	s.Session.CandidateCond.L.Lock()
-	s.Session.CandidateCond.Wait()
-	s.Session.CandidateCond.L.Unlock()
-
 	sdpOffer := s.Session.Conn.LocalDescription()
-	encodedSDP, err := utils.EncodeSDP(sdpOffer)
+	s.Session.WaitGatherComplete()
+	encodedSDP, err := utils.EncodeSDP(sdpOffer, s.Session.Candidates)
 	if err != nil {
 		return "", err
 	}
@@ -49,12 +45,5 @@ func (s *Sender) createChs() error {
 		return err
 	}
 	s.Session.DataChHandler(ch)
-
-	ch, err = s.Session.Conn.CreateDataChannel("candidate", nil)
-	if err != nil {
-		return err
-	}
-	s.Session.CandidateChHandler(ch)
-
 	return nil
 }

--- a/sender/transferInfo.go
+++ b/sender/transferInfo.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *Sender) ProposeTransfer(ftList []utils.FileTransfer, answerStr string) error {
-	remoteSDP, err := utils.DecodeSDP(answerStr)
+	remoteSDP, candidates, err := utils.DecodeSDP(answerStr)
 	if err != nil {
 		return err
 	}
@@ -19,7 +19,7 @@ func (s *Sender) ProposeTransfer(ftList []utils.FileTransfer, answerStr string) 
 	if err != nil {
 		return err
 	}
-
+	s.Session.AddCandidates(candidates)
 	select {
 	case <-s.Session.DataChOpen:
 		break

--- a/utils/sdp.go
+++ b/utils/sdp.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"github.com/atotto/clipboard"
 	"github.com/aymanbagabas/go-osc52/v2"
 	"github.com/pion/webrtc/v4"
@@ -12,8 +13,18 @@ import (
 	"os"
 )
 
-func EncodeSDP(sdp *webrtc.SessionDescription) (string, error) {
-	sdpJSON, err := json.Marshal(sdp)
+type SwapInfo struct {
+	Sdp        *webrtc.SessionDescription `json:"sdp"`
+	Candidates []webrtc.ICECandidateInit  `json:"candidates"`
+}
+
+func EncodeSDP(sdp *webrtc.SessionDescription, candidates []webrtc.ICECandidateInit) (string, error) {
+	info := SwapInfo{
+		Sdp:        sdp,
+		Candidates: candidates,
+	}
+
+	infoJSON, err := json.Marshal(info)
 	if err != nil {
 		return "", err
 	}
@@ -24,7 +35,7 @@ func EncodeSDP(sdp *webrtc.SessionDescription) (string, error) {
 		return "", err
 	}
 	defer g.Close()
-	if _, err = g.Write(sdpJSON); err != nil {
+	if _, err = g.Write(infoJSON); err != nil {
 		return "", err
 	}
 
@@ -35,57 +46,33 @@ func EncodeSDP(sdp *webrtc.SessionDescription) (string, error) {
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
-func DecodeSDP(in string) (*webrtc.SessionDescription, error) {
+func DecodeSDP(in string) (*webrtc.SessionDescription, []webrtc.ICECandidateInit, error) {
 	buf, err := base64.StdEncoding.DecodeString(in)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	r, err := gzip.NewReader(bytes.NewReader(buf))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer r.Close()
 
-	sdpBytes, err := io.ReadAll(r)
+	infoBytes, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var sdp webrtc.SessionDescription
-	err = json.Unmarshal(sdpBytes, &sdp)
+	var info SwapInfo
+	err = json.Unmarshal(infoBytes, &info)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	return &sdp, nil
-}
-
-func ValidateSDP(input string) error {
-	buf, err := base64.StdEncoding.DecodeString(input)
-	if err != nil {
-		return err
-	}
-	r, err := gzip.NewReader(bytes.NewReader(buf))
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	sdpBytes, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	var sdp webrtc.SessionDescription
-	err = json.Unmarshal(sdpBytes, &sdp)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return info.Sdp, info.Candidates, nil
 }
 
 func CopyGeneratedSDPPrompt(sdp string) {
 	clipboard.WriteAll(sdp)
+	fmt.Println("You can manually copy the following content:")
+	fmt.Println(sdp)
 	osc52.New(sdp).WriteTo(os.Stderr)
 }


### PR DESCRIPTION
Using a data channel to send candidate addresses is incorrect because establishing the data channel itself relies on candidate addresses. The previous code worked only because a small portion of candidate addresses was included in the SDP, but this should not be relied upon!

Reasons are as follows:

1.When two computers cannot connect directly, this small portion of candidate addresses is useless because it usually only contains local addresses, which cannot establish a data channel.
2.As far as I know, the WebRTC protocol does not guarantee that all candidate addresses will be included in the SDP.

After modifying the code, file transfer was successfully completed between two distant computers (via a TURN server relay), which the previous code could not achieve.